### PR TITLE
Adding the preprocess capabilities of cpp in the retest too

### DIFF
--- a/src/ANSTE/Test/Test.pm
+++ b/src/ANSTE/Test/Test.pm
@@ -745,7 +745,10 @@ sub reloadVars
     my $file = $suite->{file};
     my $varfile = $suite->{varfile};
 
-    my ($suiteYAML) = YAML::XS::LoadFile($file);
+    my $tempProcessedFile = ANSTE::Util::processYamlFile($file);
+
+    my ($suiteYAML) = YAML::XS::LoadFile($tempProcessedFile);
+    system("rm -f $tempProcessedFile");
 
     my $global = $suiteYAML->{global};
     my $newGlobal = undef;


### PR DESCRIPTION
A retest could fail because there is acomment in cpp mode and we
don't pass the cpp to the yaml