### PR TITLE
-jump-to option means also reuse

### DIFF
--- a/src/bin/anste
+++ b/src/bin/anste
@@ -158,6 +158,7 @@ if ($reuse or $jump) {
 }
 if ($jump) {
     $config->setJump($jump);
+    $reuse = 1;
 }
 if ($step) {
     $config->setStep(1);


### PR DESCRIPTION
It was already taken care but not in the bin/anste file. 
This avoids: 

    WARNING: The above virtual machines are running.
    Press any key to continue or Control-C to stop.
