### PR TITLE
Avoid warning on test type reboot

### DIFF
--- a/src/ANSTE/Test/Runner.pm
+++ b/src/ANSTE/Test/Runner.pm
@@ -459,11 +459,13 @@ sub _runTest
         }
     } else {
         my $cmd = $test->shellcmd();
-        my ($fh, $filename) = tempfile() or die "Can't create temporary script file: $!";
-        $path = $filename;
-        print $fh "#!/bin/bash\n";
-        print $fh "$cmd\n";
-        close($fh) or die "Can't close temporary script file: $!";
+        if ($cmd) {
+            my ($fh, $filename) = tempfile() or die "Can't create temporary script file: $!";
+            $path = $filename;
+            print $fh "#!/bin/bash\n";
+            print $fh "$cmd\n";
+            close($fh) or die "Can't close temporary script file: $!";
+        }
     }
 
     my $logPath = $config->logPath();

--- a/src/ANSTE/Test/Test.pm
+++ b/src/ANSTE/Test/Test.pm
@@ -427,11 +427,11 @@ sub setScript
 
 # Method: shellcmd
 #
-#   Gets the directory of the test shellcmds.
+#   Gets the shell command to test.
 #
 # Returns:
 #
-#   string - Name of the directory of this test.
+#   string - the shell command to test
 #
 sub shellcmd
 {
@@ -442,11 +442,11 @@ sub shellcmd
 
 # Method: setShellCmd
 #
-#   Sets the directory for this test object to the given value.
+#   Sets the shell command for this test object to the given value.
 #
 # Parameters:
 #
-#   name - String with the relative path of the test directory.
+#   name - String with the shell command for this test object
 #
 # Exceptions:
 #


### PR DESCRIPTION
Like this one:

  Running test (2/61): RebootBackendsNode in host backends.devel.zentyal.lan
  Use of uninitialized value $cmd in concatenation (.) or string at /usr/share/perl5/ANSTE/Test/Runner.pm line 465.

I've also updated the doc for shellCmd ANSTE::Test::Test module