### PR TITLE
Check invalid breakpoints and notify

### DIFF
--- a/src/ANSTE/Config.pm
+++ b/src/ANSTE/Config.pm
@@ -1846,6 +1846,25 @@ sub breakpoint
     return $self->{breakpoints}->{$name};
 }
 
+# Method: breakpoints
+#
+#   Get the defined breakpoints
+#
+# Returns:
+#
+#   array ref - the breakpoint names
+#
+sub breakpoints
+{
+    my ($self) = @_;
+
+    if (exists ($self->{breakpoints})) {
+        my @bks = keys %{$self->{breakpoints}};
+        return \@bks;
+    }
+    return [];
+}
+
 sub _filePath
 {
     my ($self, $file) = @_;

--- a/src/ANSTE/Validate.pm
+++ b/src/ANSTE/Validate.pm
@@ -392,4 +392,34 @@ sub template
     return -r $file;
 }
 
+# Function: breakpoints
+#
+#   Checks if the given breakpoints are in the given testsuite
+#
+# Parameters:
+#
+#   suite - <ANSTE::Test::Suite> the test suite to check against
+#
+#   breakpoints - Array ref of Strings with the given breakpoints
+#
+# Returns:
+#
+#   array ref - containing invalid breakpoint names
+#
+sub breakpoints
+{
+    my ($suite, $breakpoints) = @_;
+
+    my @invalidBreakpoints;
+    my %tests = map { $_->name() => 1 } @{$suite->tests()};
+
+    foreach my $breakpoint (@{$breakpoints}) {
+        unless (exists $tests{$breakpoint}) {
+            push (@invalidBreakpoints, $breakpoint);
+        }
+    }
+
+    return \@invalidBreakpoints;
+}
+
 1;

--- a/src/bin/anste
+++ b/src/bin/anste
@@ -441,6 +441,10 @@ sub test
         if (ANSTE::Validate::suite($file)) {
             my $suite = new ANSTE::Test::Suite;
             $suite->loadFromDir($file, $varfile);
+            my $invalidBreaks = ANSTE::Validate::breakpoints($suite, $config->breakpoints());
+            if (@{$invalidBreaks}) {
+                print STDERR "The following breakpoints are not defined, skipping: " . join(", ", @{$invalidBreaks}) . "\n";
+            }
             $runner->runSuite($suite);
         } else {
             $runner->runDir($file);


### PR DESCRIPTION
The following line is shown to the user:

   The following breakpoints are not defined, skipping: FOO, RunMailReply